### PR TITLE
fix: Remove duplicate default export in component mapping generation

### DIFF
--- a/scripts/generate-component-mapping/output-formatter.js
+++ b/scripts/generate-component-mapping/output-formatter.js
@@ -602,8 +602,5 @@ export const openWebUIComponentMappings: OpenWebUIComponentMappings = {
 } as const;
 
 // Default export for convenience
-export default openWebUIComponentMappings;
-
-// Re-export component mappings as the most commonly used export
-export { componentMappings as default } from './generated-component-mapping';`;
+export default openWebUIComponentMappings;`;
 }

--- a/src/schemas/generated-component-mapping.ts
+++ b/src/schemas/generated-component-mapping.ts
@@ -8,7 +8,7 @@
  * The component mappings define which React components should be used for each
  * configuration field, along with their props, wrappers, and alternatives.
  *
- * Generated at: 2025-08-28T16:30:28.640Z
+ * Generated at: 2025-08-28T17:43:35.143Z
  * Total fields processed: 370
  *
  * Component Assignment Statistics:
@@ -6807,7 +6807,7 @@ export const openWebUIComponentMappings: OpenWebUIComponentMappings = {
   wrappers: fieldWrappers,
   integration: integrationMetadata,
   metadata: {
-    generatedAt: '2025-08-28T16:30:28.640Z',
+    generatedAt: '2025-08-28T17:43:35.143Z',
     totalFields: 370,
     version: '1.0.0',
   },
@@ -6815,6 +6815,3 @@ export const openWebUIComponentMappings: OpenWebUIComponentMappings = {
 
 // Default export for convenience
 export default openWebUIComponentMappings;
-
-// Re-export component mappings as the most commonly used export
-export { componentMappings as default } from './generated-component-mapping';


### PR DESCRIPTION
Fixed build error caused by duplicate default exports in generated-component-mapping.ts.

The output-formatter.js script was generating a circular import that created duplicate default exports. Removed the problematic re-export line, keeping only the main default export.

Fixes #16

Generated with [Claude Code](https://claude.ai/code)