### PR TITLE
fix: correct ESLint configuration for @typescript-eslint/recommended

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,12 +3,12 @@ module.exports = {
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',
-    '@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
-  plugins: ['react-refresh'],
+  plugins: ['react-refresh', '@typescript-eslint'],
   rules: {
     'react-refresh/only-export-components': [
       'warn',


### PR DESCRIPTION
Fixes GitHub Actions build failure with ESLint configuration error.

## Changes
- Change '@typescript-eslint/recommended' to 'plugin:@typescript-eslint/recommended' in extends
- Add '@typescript-eslint' to plugins array

Resolves #27

Generated with [Claude Code](https://claude.ai/code)