### PR TITLE
fix: remove development toggles and fix form rendering issues

### DIFF
--- a/.wrangler/deploy/config.json
+++ b/.wrangler/deploy/config.json
@@ -1,0 +1,1 @@
+{"configPath":"../../dist/openwebui_config_tool/wrangler.json","auxiliaryWorkers":[]}

--- a/schemas/ui-schema.json
+++ b/schemas/ui-schema.json
@@ -2,8 +2,6 @@
   "$schema": "https://schemas.openwebui.com/ui-schema/v1",
   "ui:title": "OpenWebUI Configuration",
   "ui:description": "Configure your OpenWebUI deployment",
-  "ui:ObjectFieldTemplate": "CategoryObjectTemplate",
-  "ui:FieldTemplate": "AdvancedFieldTemplate",
   "app": {
     "ui:title": "App Settings",
     "ui:collapsible": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react'
 import { ModeToggle } from '@/components/mode-toggle'
-import { ConfigForm } from '@/components/config-form'
 import { ConfigFormRJSF } from '@/components/config-form-rjsf'
-import { ConfigFormWithNavigation } from '@/components/config-form-with-navigation'
 import { RawEditor } from '@/components/raw-editor'
 import { ImportControls } from '@/components/import-controls'
 import { ExportControls } from '@/components/export-controls'
@@ -16,8 +14,6 @@ export default function App() {
   const [configData, setConfigData] = useState<ConfigData>({})
   const [rawContent, setRawContent] = useState('')
   const [isLoading, setIsLoading] = useState(true)
-  const [useRJSF, setUseRJSF] = useState(false) // Development toggle
-  const [useNavigation, setUseNavigation] = useState(false) // Navigation toggle
   
   // Initialize app state from localStorage
   useEffect(() => {
@@ -119,28 +115,6 @@ export default function App() {
           onModeChange={handleModeChange}
         />
         
-        {/* Development Toggles */}
-        <div className="mb-4 p-4 bg-muted/50 rounded-lg space-y-2">
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={useRJSF}
-              onChange={(e) => setUseRJSF(e.target.checked)}
-            />
-            Use RJSF Form (Development)
-          </label>
-          {useRJSF && (
-            <label className="flex items-center gap-2 text-sm ml-4">
-              <input
-                type="checkbox"
-                checked={useNavigation}
-                onChange={(e) => setUseNavigation(e.target.checked)}
-              />
-              Use Navigation Layout (Task 19)
-            </label>
-          )}
-        </div>
-        
         {/* Import/Export Controls */}
         <div className="grid md:grid-cols-2 gap-4 mb-6">
           <ImportControls 
@@ -156,24 +130,10 @@ export default function App() {
         
         {/* Main Editor */}
         {mode === 'form' ? (
-          useRJSF ? (
-            useNavigation ? (
-              <ConfigFormWithNavigation 
-                data={configData}
-                onDataChange={handleConfigDataChange}
-              />
-            ) : (
-              <ConfigFormRJSF 
-                data={configData}
-                onDataChange={handleConfigDataChange}
-              />
-            )
-          ) : (
-            <ConfigForm 
-              data={configData}
-              onDataChange={handleConfigDataChange}
-            />
-          )
+          <ConfigFormRJSF 
+            data={configData}
+            onDataChange={handleConfigDataChange}
+          />
         ) : (
           <RawEditor 
             content={rawContent}

--- a/src/schemas/ui-schema.json
+++ b/src/schemas/ui-schema.json
@@ -2,8 +2,6 @@
   "$schema": "https://schemas.openwebui.com/ui-schema/v1",
   "ui:title": "OpenWebUI Configuration",
   "ui:description": "Configure your OpenWebUI deployment",
-  "ui:ObjectFieldTemplate": "CategoryObjectTemplate",
-  "ui:FieldTemplate": "AdvancedFieldTemplate",
   "app": {
     "ui:title": "App Settings",
     "ui:collapsible": true,


### PR DESCRIPTION
Fixes #51

## Changes
- Remove RJSF development toggle - RJSF is now the only form option
- Remove navigation layout toggle referencing incomplete task-019
- Fix category rendering by removing non-existent template references
- Simplify App.tsx to only use ConfigFormRJSF component

Generated with [Claude Code](https://claude.ai/code)