### PR TITLE
kfix: update ui-schema.json ui:order to match actual schema properties

### DIFF
--- a/schemas/ui-schema.json
+++ b/schemas/ui-schema.json
@@ -2056,25 +2056,15 @@
     }
   },
   "ui:order": [
-    "WEBUI_URL",
-    "ENABLE_SIGNUP",
-    "ENABLE_LOGIN_FORM",
-    "DEFAULT_LOCALE",
-    "DEFAULT_MODELS",
-    "DEFAULT_USER_ROLE",
-    "PENDING_USER_OVERLAY_TITLE",
-    "PENDING_USER_OVERLAY_CONTENT",
-    "ENABLE_CHANNELS",
-    "WEBHOOK_URL",
-    "ENABLE_ADMIN_EXPORT",
-    "ENABLE_ADMIN_CHAT_ACCESS",
-    "ENABLE_USER_WEBHOOKS",
-    "RESPONSE_WATERMARK",
-    "THREAD_POOL_SIZE",
-    "SHOW_ADMIN_DETAILS",
-    "ADMIN_EMAIL",
-    "ENV",
-    "ENABLE_PERSISTENT_CONFIG",
-    "CUSTOM_NAME"
+    "app",
+    "security",
+    "vector",
+    "rag",
+    "retrieval",
+    "web",
+    "audio",
+    "image",
+    "user",
+    "misc"
   ]
 }


### PR DESCRIPTION
Fixes #53

The ui:order at the root level was listing individual field names that don't exist at the root level of the schema. Updated it to list the actual top-level category properties: app, security, vector, rag, retrieval, web, audio, image, user, misc.

This fixes the form rendering error: 'Invalid root object field configuration: uiSchema order list does not contain properties...'

Generated with [Claude Code](https://claude.ai/code)